### PR TITLE
Multiple improvements for command line tools

### DIFF
--- a/ctl
+++ b/ctl
@@ -68,7 +68,7 @@ def help():
     print("\n%s: Command Line Tools for Chef\n" % INVOKENAME)
     print("Commands:")
     for c in ['build', 'run', 'vm']:
-        print("  {:<15}: {}".format(c, COMMANDS[c]['description']))
+        print("  {:<6}  {}".format(c, COMMANDS[c]['description']))
     print("\nEach command can be run with `-h` for more information")
     exit(1)
 

--- a/ctltools/run.py
+++ b/ctltools/run.py
@@ -346,6 +346,16 @@ def build_qemu_cmd_line(args):
         utils.fail('%s: VM does not exist' % vm.name)
         exit(1)
 
+    # VM image:
+    if args['mode'] == 'kvm':
+        qemu_drive_options = 'if=virtio,format=raw'
+    else:
+        qemu_drive_options = 'cache=writeback,format=s2e'
+    qemu_cmd_line.extend([
+        '-drive',
+        'file=%s,%s' % (vm.path_raw, qemu_drive_options)
+    ])
+
     # Snapshots:
     if args['snapshot']:
         if args['snapshot'] not in vm.snapshots:
@@ -386,9 +396,6 @@ def build_qemu_cmd_line(args):
             '-s2e-verbose'
         ])
         qemu_cmd_line.extend(['-s2e-output-dir', args['exppath']])
-
-    # VM path:
-    qemu_cmd_line.append((vm.path_s2e, vm.path_raw)[args['mode'] == 'kvm'])
 
     return qemu_cmd_line
 

--- a/ctltools/run.py
+++ b/ctltools/run.py
@@ -340,10 +340,6 @@ def build_qemu_cmd_line(args):
     # Base command:
     qemu_cmd_line.append(qemu_path);
 
-    # User-defined qemu options:
-    if args['qemu_opts']:
-        qemu_cmd_line.extend(args['qemu_opts'])
-
     # VM:
     vm = VM(args['VM'])
     if not os.path.exists(vm.path_raw):
@@ -401,6 +397,10 @@ def build_qemu_cmd_line(args):
             '-s2e-verbose'
         ])
         qemu_cmd_line.extend(['-s2e-output-dir', args['exppath']])
+
+    # User-defined qemu options:
+    if args['qemu_opts']:
+        qemu_cmd_line.extend(args['qemu_opts'])
 
     return qemu_cmd_line
 

--- a/ctltools/utils.py
+++ b/ctltools/utils.py
@@ -12,7 +12,8 @@ import stat
 # EXECUTION ====================================================================
 
 def execute(cmd:[str], stdin:str=None, stdout:bool=False, stderr:bool=False,
-            msg:str=None, iowrap:bool=False, outfile:str=None, env:dict=None):
+            msg:str=None, iowrap:bool=False, outfile:str=None, env:dict=None,
+            exit_on_fail:int=1):
     interrupted = False
     environ = dict(os.environ)
     if env:
@@ -44,6 +45,8 @@ def execute(cmd:[str], stdin:str=None, stdout:bool=False, stderr:bool=False,
         except KeyboardInterrupt:
             abort("second keyboard interrupt")
         exit(127) # XXX does not allow cleanup
+    if sp.returncode != 0 and exit_on_fail:
+        exit(exit_on_fail)
     if iowrap:
         return out.decode(), err.decode(), sp.returncode
     else:
@@ -63,7 +66,6 @@ def which(cmd:str):
         if os.path.exists(fullpath):
             return fullpath
     return None
-
 
 # S2E/CHEF =====================================================================
 
@@ -206,6 +208,7 @@ if sys.stdout.isatty() and sys.stderr.isatty():
     ESC_RESET = '\033[0m'
     ESC_ERASE = '\033[K'
     ESC_RETURN = '\r'
+    ESC_BOLD = '\033[1m'
 else:
     ESC_ERROR = ''
     ESC_SUCCESS = ''
@@ -215,6 +218,7 @@ else:
     ESC_RESET = ''
     ESC_ERASE = ''
     ESC_RETURN = '\n'
+    ESC_BOLD = ''
 
 WARN = '[%sWARN%s]' % (ESC_WARNING, ESC_RESET)
 FAIL = '[%sFAIL%s]' % (ESC_ERROR, ESC_RESET)

--- a/ctltools/utils.py
+++ b/ctltools/utils.py
@@ -11,6 +11,15 @@ import stat
 
 # EXECUTION ====================================================================
 
+# cmd: command to be executed
+# stdin: the string to be sent to the process on stdin
+# stdout: whether to display stdout on the terminal
+# stderr: whether to display stderr on the terminal
+# msg: elliptic description of what the process is doing (used in case it fails)
+# iowrap: whether to return a tuple (retval, stdout, stderr)
+# outfile: file to which stdout is redirected
+# env: environment to be used for the process
+# exit_on_fail: whether to exit (instead of returning) if there is a failure
 def execute(cmd:[str], stdin:str=None, stdout:bool=False, stderr:bool=False,
             msg:str=None, iowrap:bool=False, outfile:str=None, env:dict=None,
             exit_on_fail:int=1):
@@ -48,7 +57,7 @@ def execute(cmd:[str], stdin:str=None, stdout:bool=False, stderr:bool=False,
     if sp.returncode != 0 and exit_on_fail:
         exit(exit_on_fail)
     if iowrap:
-        return out.decode(), err.decode(), sp.returncode
+        return sp.returncode, out.decode(), err.decode()
     else:
         return sp.returncode
 

--- a/ctltools/vm.py
+++ b/ctltools/vm.py
@@ -154,6 +154,8 @@ class VM:
         os.unlink(tar)
         utils.ok()
 
+        self.scan_snapshots()
+
 
     def _import(self, targz: str, force: bool, **kwargs: dict):
         if not os.path.exists(targz):
@@ -212,24 +214,15 @@ class VM:
         new = VM(clone)
         new.initialise(force)
 
+        # http://bugs.python.org/issue10016
         utils.pend("copy disk image", msg="may take some time")
-        try:
-            shutil.copy(self.path_raw, new.path_raw)
-            utils.ok()
-        except KeyboardInterrupt as ki:
-            utils.abort("%s" % ki)
-            exit(127)
+        utils.execute(['cp', self.path_raw, new.path_raw])
+        utils.ok()
 
         for s in self.snapshots:
             utils.pend("copy snapshot: %s" % s)
-            try:
-                shutil.copy('%s/%s.%s'
-                            % (self.path, os.path.basename(self.path_raw), s),
-                            new.path)
-                utils.ok()
-            except KeyboardInterrupt as ki:
-                utils.abort("%s" % ki)
-                exit(127)
+            utils.execute(['cp', '%s.%s' % (self.path_raw, s), new.path])
+            utils.ok()
         new.scan_snapshots()
 
 

--- a/ctltools/vm.py
+++ b/ctltools/vm.py
@@ -169,13 +169,13 @@ class VM:
 
     # ACTIONS ==================================================================
 
-    def create(self, size: int, force: bool, **kwargs: dict):
+    def create(self, size: str, force: bool, **kwargs: dict):
         self.initialise(force)
 
         # Raw image:
-        utils.pend("create %dMiB image" % size)
+        utils.pend("create %sB image" % size)
         if utils.execute(['%s/qemu-img' % self.path_executable,
-                          'create', self.path_raw, '%dM' % size],
+                          'create', self.path_raw, size],
                          msg="execute qemu-img") != 0:
             exit(1)
         self.size = size
@@ -315,8 +315,8 @@ class VM:
                              help="Force creation, even if VM already exists")
         pcreate.add_argument('name',
                              help="Machine name")
-        pcreate.add_argument('size', type=int, default=5120, nargs='?',
-                             help="VM size (in MB) [default=5120]")
+        pcreate.add_argument('size', default='5120M', nargs='?',
+                             help="VM size [default=5120M]")
 
         # install
         pinstall = pcmd.add_parser('install',


### PR DESCRIPTION
- `ctl vm` now supports importing (issue #33), exporting (issue #34), and cloning (issue #32), which can be handy for distributing and sharing VMs and snapshots.
- `ctl vm install` is removed (issue #35). Installing a custom ISO to a VM can still be done by using the `-q` option to `ctl run`: its arguments are directly passed to the underlying qemu process (issue #37).
- `ctl vm delete` now also supports deleting single snapshots through the `vmname:snapshot` notation. If `:snapshot` is omitted, the entire VM is deleted (previous behaviour), but additionally asks for a confirmation (issue #39).
- S²E seems to have a limitation on the image file name suffix (`.s2e`), but qemu does not. Hence, we now use the `.s2e` suffix for both the KVM and non-KVM running modes, simplifying the file structure (issue #38).
- `ctl run` launches VMs with X output by default now. The previous behaviour (headless, with VNC) can still be achieved by passing the `--headless` option (issue #36).
- The size argument for `ctl vm create` is now passed directly to the underlying qemu-img process. This allows the user to use size specifiers (`k`, `K`, `M`, `G`), which is more intuitive than being fixed on mebibytes (issue #31).
- In general, the file structure for VMs is greatly simplified: there are no `defunct` or `meta` files anymore, only the raw VM image itself + user-generated snapshot files.
