### PR TITLE
Fix setup script, switch to downloading sources from github and ignore certificate checks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "guest"]
 	path = guest
-	url = git@github.com:dslab-epfl/s2e-guest.git
+	url = https://github.com/dslab-epfl/s2e-guest.git

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -54,7 +54,7 @@ protobuf_fetch()
 {
 	protobuf_dirname="protobuf-2.6.0"
 	protobuf_tarball="${protobuf_dirname}.tar.gz"
-	protobuf_url="https://protobuf.googlecode.com/svn/rc/$protobuf_tarball"
+	protobuf_url="https://github.com/protocolbuffers/protobuf/archive/refs/tags/v2.6.0.tar.gz"
 
 	test ! -e "$protobuf_tarball" || return $SKIPPED
 	if ! wget --no-check-certificate -O "$protobuf_tarball" "$protobuf_url"; then

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -40,6 +40,7 @@ z3_extract()
 z3_configure()
 {
     mv "z3-z3-4.11.2"/* . || return $FAILURE
+    mv "z3-z3-4.11.2"/.* . || return $FAILURE
     rm -d "z3-z3-4.11.2" || return "$FAILURE"
 	python2 scripts/mk_make.py || return $FAILURE
 }

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -18,7 +18,7 @@ COMPS_LLVM='clang compiler-rt llvm-native llvm llvm'
 
 # Z3 ===========================================================================
 
-z3_url='http://download-codeplex.sec.s-msft.com/Download/SourceControlFileDownload.ashx?ProjectName=z3&changeSetId=dd62ca5eb36c2a62ee44fc5a79fc27c883de21ae'
+z3_url='https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.11.2.zip'
 z3_tarball='z3.zip'
 
 z3_fetch()

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -18,29 +18,28 @@ COMPS_LLVM='clang compiler-rt llvm-native llvm llvm'
 
 # Z3 ===========================================================================
 
-z3_url='https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.3.0.zip'
-z3_tarball='z3.zip'
+z3_url='https://github.com/Z3Prover/z3.git'
+z3_commit='dd62ca5eb36c2a62ee44fc5a79fc27c883de21ae'
 
 z3_fetch()
 {
-	if [ -e "$z3_tarball" ]; then
-		return $SKIPPED
-	fi
-	if ! wget -O "$z3_tarball" "$z3_url"; then
-		rm -f "$z3_tarball"
-		return $FAILURE
-	fi
+    if [ -e z3 ]; then
+        return $SKIPPED
+    fi
+
+    git clone "$z3_url" "$DSTPATH" || return $FAILURE
 }
 
 z3_extract()
 {
-	unzip -d "$DSTPATH" "$z3_tarball" || return $FAILURE
+    # Switch to a correct commit
+    cd "$DSTPATH" || return $FAILURE
+    git checkout "$z3_commit" || return $FAILURE
+    cd .. || return $FAILURE
 }
 
 z3_configure()
 {
-    mv "z3-z3-4.3.0"/* . || return $FAILURE
-    rm -rf "z3-z3-4.3.0" || return "$FAILURE"
 	python2 scripts/mk_make.py || return $FAILURE
 }
 

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -57,7 +57,7 @@ protobuf_fetch()
 	protobuf_url="https://protobuf.googlecode.com/svn/rc/$protobuf_tarball"
 
 	test ! -e "$protobuf_tarball" || return $SKIPPED
-	if ! wget -O "$protobuf_tarball" "$protobuf_url"; then
+	if ! wget --no-check-certificate -O "$protobuf_tarball" "$protobuf_url"; then
 		rm -f "$protobuf_tarball"
 		return $FAILURE
 	fi
@@ -86,7 +86,7 @@ llvm_generic_fetch()
 	llvm_generic_url="$llvm_generic_urlbase/$llvm_generic_tarball"
 
 	test ! -e "$llvm_generic_tarball" || return $SKIPPED
-	if ! wget -O "$llvm_generic_tarball" "$llvm_generic_url"; then
+	if ! wget --no-check-certificate -O "$llvm_generic_tarball" "$llvm_generic_url"; then
 		rm -f "$llvm_generic_tarball"
 		return $FAILURE
 	fi
@@ -223,7 +223,7 @@ lua_url="http://www.lua.org/ftp/$lua_tarball"
 lua_fetch()
 {
 	test ! -e "$lua_tarball" || return $SKIPPED
-	if ! wget -O "$lua_tarball" "$lua_url"; then
+	if ! wget --no-check-certificate -O "$lua_tarball" "$lua_url"; then
 		rm -f "$lua_tarball"
 		return $FAILURE
 	fi

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -40,11 +40,7 @@ z3_extract()
 z3_configure()
 {
     mv "z3-z3-4.1.1"/* . || return $FAILURE
-    mv "z3-z3-4.1.1"/.dockerignore . || return $FAILURE
-    mv "z3-z3-4.1.1"/.gitattributes . || return $FAILURE
-    mv "z3-z3-4.1.1"/.github . || return $FAILURE
-    mv "z3-z3-4.1.1"/.gitignore . || return $FAILURE
-    rm -d "z3-z3-4.1.1" || return "$FAILURE"
+    rm -rf "z3-z3-4.1.1" || return "$FAILURE"
 	python2 scripts/mk_make.py || return $FAILURE
 }
 

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -74,7 +74,8 @@ protobuf_configure()
     # Fetch gtest
     wget --no-check-certificate "https://github.com/google/googletest/archive/refs/tags/release-1.5.0.zip" -O gtest.zip || return $FAILURE
     unzip gtest.zip || return $FAILURE
-    mv gtest-1.5.0 gtest || return $FAILURE
+    mv googletest-release-1.5.0 gtest || return $FAILURE
+    rm gtest.zip || return $FAILURE
     ./autogen.sh || return $FAILURE
 	./configure || return $FAILURE
 }

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -40,7 +40,10 @@ z3_extract()
 z3_configure()
 {
     mv "z3-z3-4.11.2"/* . || return $FAILURE
-    mv "z3-z3-4.11.2"/.* . || return $FAILURE
+    mv "z3-z3-4.11.2"/.dockerignore . || return $FAILURE
+    mv "z3-z3-4.11.2"/.gitattributes . || return $FAILURE
+    mv "z3-z3-4.11.2"/.github . || return $FAILURE
+    mv "z3-z3-4.11.2"/.gitignore . || return $FAILURE
     rm -d "z3-z3-4.11.2" || return "$FAILURE"
 	python2 scripts/mk_make.py || return $FAILURE
 }

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -18,7 +18,7 @@ COMPS_LLVM='clang compiler-rt llvm-native llvm llvm'
 
 # Z3 ===========================================================================
 
-z3_url='https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.1.1.zip'
+z3_url='https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.3.0.zip'
 z3_tarball='z3.zip'
 
 z3_fetch()
@@ -39,8 +39,8 @@ z3_extract()
 
 z3_configure()
 {
-    mv "z3-z3-4.1.1"/* . || return $FAILURE
-    rm -rf "z3-z3-4.1.1" || return "$FAILURE"
+    mv "z3-z3-4.3.0"/* . || return $FAILURE
+    rm -rf "z3-z3-4.3.0" || return "$FAILURE"
 	python2 scripts/mk_make.py || return $FAILURE
 }
 

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -71,6 +71,12 @@ protobuf_extract()
 
 protobuf_configure()
 {
+    mv protobuf/* . || return $FAILURE
+    rm -rf protobuf/ || return $FAILURE
+    # Fetch gtest
+    wget --no-check-certificate "https://github.com/google/googletest/archive/refs/tags/release-1.5.0.zip" -O gtest.zip || return $FAILURE
+    unzip gtest.zip || return $FAILURE
+    mv gtest-1.5.0 gtest || return $FAILURE
 	./configure || return $FAILURE
 }
 

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -18,7 +18,7 @@ COMPS_LLVM='clang compiler-rt llvm-native llvm llvm'
 
 # Z3 ===========================================================================
 
-z3_url='https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.11.2.zip'
+z3_url='https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.1.1.zip'
 z3_tarball='z3.zip'
 
 z3_fetch()
@@ -39,12 +39,12 @@ z3_extract()
 
 z3_configure()
 {
-    mv "z3-z3-4.11.2"/* . || return $FAILURE
-    mv "z3-z3-4.11.2"/.dockerignore . || return $FAILURE
-    mv "z3-z3-4.11.2"/.gitattributes . || return $FAILURE
-    mv "z3-z3-4.11.2"/.github . || return $FAILURE
-    mv "z3-z3-4.11.2"/.gitignore . || return $FAILURE
-    rm -d "z3-z3-4.11.2" || return "$FAILURE"
+    mv "z3-z3-4.1.1"/* . || return $FAILURE
+    mv "z3-z3-4.1.1"/.dockerignore . || return $FAILURE
+    mv "z3-z3-4.1.1"/.gitattributes . || return $FAILURE
+    mv "z3-z3-4.1.1"/.github . || return $FAILURE
+    mv "z3-z3-4.1.1"/.gitignore . || return $FAILURE
+    rm -d "z3-z3-4.1.1" || return "$FAILURE"
 	python2 scripts/mk_make.py || return $FAILURE
 }
 

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -71,12 +71,11 @@ protobuf_extract()
 
 protobuf_configure()
 {
-    mv protobuf/* . || return $FAILURE
-    rm -rf protobuf/ || return $FAILURE
     # Fetch gtest
     wget --no-check-certificate "https://github.com/google/googletest/archive/refs/tags/release-1.5.0.zip" -O gtest.zip || return $FAILURE
     unzip gtest.zip || return $FAILURE
     mv gtest-1.5.0 gtest || return $FAILURE
+    ./autogen.sh || return $FAILURE
 	./configure || return $FAILURE
 }
 

--- a/ctltools/build.sh
+++ b/ctltools/build.sh
@@ -39,6 +39,8 @@ z3_extract()
 
 z3_configure()
 {
+    mv "z3-z3-4.11.2"/* . || return $FAILURE
+    rm -d "z3-z3-4.11.2" || return "$FAILURE"
 	python2 scripts/mk_make.py || return $FAILURE
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -38,10 +38,14 @@ fi
 
 # Add user to kvm group:
 if ! getent group kvm; then
-	sudo groupadd -r -g 78 kvm
+	groupadd -r -g 78 kvm
 fi
 if ! getent group kvm | grep $(id -un); then
-	sudo usermod -a -G kvm $(id -u)
+    if [ $(id -u) -eq 0 ]; then
+        usermod -a -G kvm root
+    else
+        usermod -a -G kvm $(id -u)
+    fi
 fi
 
 # dependencies for Chef:

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,8 @@
 set -e
 
 # check UID:
-if [ "$(id -u)" = '0' ]; then
-	echo 'Please do not run this script as root.'
+if [ "$(id -u)" != '0' ]; then
+	echo 'Please Run this script as root.'
 	exit 1
 fi
 
@@ -12,16 +12,16 @@ fi
 cd "$(readlink -f "$(dirname "$0")")"
 
 # update package tree:
-sudo apt-get update -y
+apt-get update -y
 
 # dependencies for S²E:
-sudo apt-get install -y build-essential subversion git gettext python-docutils python-pygments nasm unzip wget liblua5.1-dev libsdl1.2-dev libsigc++-2.0-dev binutils-dev libiberty-dev libc6-dev-i386
-sudo apt-get build-dep -y llvm-3.3 qemu
+apt-get install -y build-essential subversion git gettext python-docutils python-pygments nasm unzip wget liblua5.1-dev libsdl1.2-dev libsigc++-2.0-dev binutils-dev libiberty-dev libc6-dev-i386
+apt-get build-dep -y llvm-3.3 qemu
 
 # compile and install Z3:
 ./ctl build -p z3
 cd ../build/deps/z3/
-sudo make -C build install
+make -C build install
 cd -
 
 # compile LLVM:
@@ -45,14 +45,14 @@ if ! getent group kvm | grep $(id -un); then
 fi
 
 # dependencies for Chef:
-sudo apt-get install -y gdb strace libdwarf-dev libelf-dev libboost-dev libsqlite3-dev libmemcached-dev libboost-serialization-dev libboost-system-dev
+apt-get install -y gdb strace libdwarf-dev libelf-dev libboost-dev libsqlite3-dev libmemcached-dev libboost-serialization-dev libboost-system-dev
 
 # compile and install protobuf:
 ./ctl build -p protobuf
 cd ../build/deps/protobuf/
-sudo make install
-sudo ldconfig
+make install
+ldconfig
 cd -
 
 # dependencies for ctl:
-sudo apt-get install -y coreutils python3 python3-netifaces python3-psutil python3-requests python3-yaml parallel
+apt-get install -y coreutils python3 python3-netifaces python3-psutil python3-requests python3-yaml parallel

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,8 @@
 set -e
 
 # check UID:
-if [ "$(id -u)" != '0' ]; then
-	echo 'Please Run this script as root.'
+if [ "$(id -u)" = '0' ]; then
+	echo 'Please do not run this script as root.'
 	exit 1
 fi
 
@@ -12,16 +12,16 @@ fi
 cd "$(readlink -f "$(dirname "$0")")"
 
 # update package tree:
-apt-get update -y
+sudo apt-get update -y
 
 # dependencies for S²E:
-apt-get install -y build-essential subversion git gettext python-docutils python-pygments nasm unzip wget liblua5.1-dev libsdl1.2-dev libsigc++-2.0-dev binutils-dev libiberty-dev libc6-dev-i386
-apt-get build-dep -y llvm-3.3 qemu
+sudo apt-get install -y build-essential subversion git gettext python-docutils python-pygments nasm unzip wget liblua5.1-dev libsdl1.2-dev libsigc++-2.0-dev binutils-dev libiberty-dev libc6-dev-i386
+sudo apt-get build-dep -y llvm-3.3 qemu
 
 # compile and install Z3:
 ./ctl build -p z3
 cd ../build/deps/z3/
-make -C build install
+sudo make -C build install
 cd -
 
 # compile LLVM:
@@ -38,25 +38,21 @@ fi
 
 # Add user to kvm group:
 if ! getent group kvm; then
-	groupadd -r -g 78 kvm
+	sudo groupadd -r -g 78 kvm
 fi
 if ! getent group kvm | grep $(id -un); then
-    if [ $(id -u) -eq 0 ]; then
-        usermod -a -G kvm root
-    else
-        usermod -a -G kvm $(id -u)
-    fi
+    sudo usermod -a -G kvm $(id -u)
 fi
 
 # dependencies for Chef:
-apt-get install -y gdb strace libdwarf-dev libelf-dev libboost-dev libsqlite3-dev libmemcached-dev libboost-serialization-dev libboost-system-dev
+sudo apt-get install -y gdb strace libdwarf-dev libelf-dev libboost-dev libsqlite3-dev libmemcached-dev libboost-serialization-dev libboost-system-dev
 
 # compile and install protobuf:
 ./ctl build -p protobuf
 cd ../build/deps/protobuf/
-make install
-ldconfig
+sudo make install
+sudo ldconfig
 cd -
 
 # dependencies for ctl:
-apt-get install -y coreutils python3 python3-netifaces python3-psutil python3-requests python3-yaml parallel
+sudo apt-get install -y coreutils python3 python3-netifaces python3-psutil python3-requests python3-yaml parallel


### PR DESCRIPTION
As of now, 2022, many of the sources that setup script downloads the dependencies from, are dead.

This pull request replaces many of those sources for github, and also disables wget certificate checks. The point is that old ubuntu apparently cannot handle new modern certificates, and it is easier to disable the checks than to handle backporting modern crypto libraries back to the old ubuntu.

Reproduction:
```docker
FROM ubuntu:14.04
RUN apt update
RUN apt install -y git

WORKDIR /s2e
RUN git clone --recursive https://github.com/SoptikHa2/chef.git src
RUN sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
RUN src/setup.sh
RUN src/ctl build
```

The commit history is a bit of a mess as I experimented with different ways of doing this, but it works now.